### PR TITLE
Update rule.stub

### DIFF
--- a/src/Commands/stubs/rule.stub
+++ b/src/Commands/stubs/rule.stub
@@ -2,7 +2,7 @@
 
 namespace DummyNamespace;
 
-use LdapRecord\Laravel\Validation\Rules\Rule;
+use LdapRecord\Laravel\Auth\Rule;
 
 class DummyClass extends Rule
 {


### PR DESCRIPTION
The namespace of the `Rule` class seems to have changed, so that the generated rules aren't working at the moment.