### PR TITLE
Introduce functionality from Adldap2-laravel

### DIFF
--- a/config/ldap.php
+++ b/config/ldap.php
@@ -70,4 +70,38 @@ return [
         'driver' => env('CACHE_DRIVER', 'file'),
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Windows Authentication Middleware (SSO)
+    |--------------------------------------------------------------------------
+    |
+    | Locate Users By:
+    |
+    |   This value is the users attribute you would like to locate LDAP
+    |   users by in your directory.
+    |
+    |   For example, if 'samaccountname' is the value, then your LDAP server is
+    |   queried for a user with the 'samaccountname' equal to the value of
+    |   $_SERVER['AUTH_USER'].
+    |
+    |   If a user is found, they are imported (if using the DatabaseUserProvider)
+    |   into your local database, then logged in.
+    |
+    | Server Key:
+    |
+    |    This value represents the 'key' of the $_SERVER
+    |    array to pull the users account name from.
+    |
+    |    For example, $_SERVER['AUTH_USER'].
+    |
+    */
+
+    'windows' => [
+
+        'locate_users_by' => 'samaccountname',
+
+        'server_key' => 'AUTH_USER',
+
+    ],
+
 ];

--- a/src/Middleware/WindowsAuthenticate.php
+++ b/src/Middleware/WindowsAuthenticate.php
@@ -59,11 +59,11 @@ class WindowsAuthenticate
      */
     protected function authenticate($request, array $guards)
     {
-        [$domain, $username] = array_pad(
-            explode('\\', $this->account($request)), 2, null
+        [$username, $domain] = array_pad(
+            array_reverse(explode('\\', $this->account($request))), 2, null
         );
 
-        if (empty($domain) || empty($username)) {
+        if (empty($username)) {
             return;
         }
 

--- a/src/Middleware/WindowsAuthenticate.php
+++ b/src/Middleware/WindowsAuthenticate.php
@@ -5,6 +5,7 @@ namespace LdapRecord\Laravel\Middleware;
 use Closure;
 use Illuminate\Contracts\Auth\Factory as Auth;
 use Illuminate\Database\Eloquent\Model as Eloquent;
+use Illuminate\Support\Facades\Config;
 use LdapRecord\Laravel\Auth\DatabaseUserProvider;
 use LdapRecord\Laravel\Auth\UserProvider;
 use LdapRecord\Laravel\Events\AuthenticatedWithWindows;
@@ -136,7 +137,7 @@ class WindowsAuthenticate
      */
     protected function getUserFromRepository(LdapUserRepository $repository, $username)
     {
-        return $repository->findBy('samaccountname', $username);
+        return $repository->findBy($this->discover(), $username);
     }
 
     /**
@@ -212,6 +213,27 @@ class WindowsAuthenticate
      */
     protected function account($request)
     {
-        return utf8_encode($request->server('AUTH_USER'));
+        return utf8_encode($request->server($this->key()));
+    }
+
+    /**
+     * Returns the configured key to use for retrieving
+     * the username from the server global variable.
+     *
+     * @return string
+     */
+    protected function key()
+    {
+        return Config::get('ldap.identifiers.windows.server_key', 'AUTH_USER');
+    }
+
+    /**
+     * Returns the attribute to discover users by.
+     *
+     * @return string
+     */
+    protected function discover()
+    {
+        return Config::get('ldap.identifiers.windows.locate_users_by', 'samaccountname');
     }
 }


### PR DESCRIPTION
While migrating from `Adldap2-Laravel` there are a few things I'm no longer able to tweak. Most of this change is sourced directly from `Adldap2-Laravel`.

The only (potentially?) controversial change here is `$domain` handling. Documentation states:
>**Important:** This is a security issue if you use multi-domain authentication and disable this check. If you only connect to one domain inside your application, this is not a security issue. You have been warned.

So allowing `WindowsAuthenticate::account` to return simple values without a domain should be supported to be consistent here.

I ran minimal testing on my setup and everything seemed to work out. I'm not familiar enough with the code base to know if I have introduced any regressions with this, but the code seemed simple enough that I assume not :man_shrugging: 