### PR TITLE
Update the default LDAP_USERNAME

### DIFF
--- a/config/ldap.php
+++ b/config/ldap.php
@@ -30,7 +30,7 @@ return [
 
         'default' => [
             'hosts' => [env('LDAP_HOST', '127.0.0.1')],
-            'username' => env('LDAP_USERNAME', 'cn=user,dc=local,dc=om'),
+            'username' => env('LDAP_USERNAME', 'cn=user,dc=local,dc=com'),
             'password' => env('LDAP_PASSWORD', 'secret'),
             'port' => env('LDAP_PORT', 389),
             'base_dn' => env('LDAP_BASE_DN', 'dc=local,dc=com'),


### PR DESCRIPTION
Update the default LDAP_USERNAME to make it consistent with the documentation (local.com)