### PR TITLE
Operator support

### DIFF
--- a/src/Import/Synchronizer.php
+++ b/src/Import/Synchronizer.php
@@ -4,7 +4,6 @@ namespace LdapRecord\Laravel\Import;
 
 use Closure;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Facades\DB;
 use LdapRecord\LdapRecordException;
 use LdapRecord\Models\Model as LdapModel;
 use LdapRecord\Laravel\Events\Import\Importing;

--- a/src/Import/Synchronizer.php
+++ b/src/Import/Synchronizer.php
@@ -4,6 +4,7 @@ namespace LdapRecord\Laravel\Import;
 
 use Closure;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\DB;
 use LdapRecord\LdapRecordException;
 use LdapRecord\Models\Model as LdapModel;
 use LdapRecord\Laravel\Events\Import\Importing;
@@ -173,7 +174,14 @@ class Synchronizer
 
         return $query->orWhere(function ($query) use ($scopes, $ldap) {
             foreach ($scopes as $databaseColumn => $ldapAttribute) {
-                $query->where($databaseColumn, '=', $ldap->getFirstAttribute($ldapAttribute) ?? $ldapAttribute);
+                $operator = is_array($ldapAttribute)
+                    ? ($ldapAttribute['operator'] ?? '=')
+                    : '=';
+                $attribute = is_array($ldapAttribute)
+                    ? ($ldapAttribute['attribute'] ?? '')
+                    : $ldapAttribute;
+
+                $query->where($databaseColumn, $operator, $ldap->getFirstAttribute($attribute) ?? $attribute);
             }
         });
     }


### PR DESCRIPTION
I've added support for an alternative syntax for the `sync_existing` configuration option, which allows for an `operator` key to replace the standard `=` operator.

Here is an example of using `ilike` as the operator in the case of postgres sql grammar.

```php
'users' => [
    'driver' => 'ldap',
    'model' => LdapRecord\Models\ActiveDirectory\User::class,
    'rules' => [
        \App\Ldap\Rules\OnlyImportedUsers::class,
    ],
    'database' => [
        'model' => App\Models\User::class,
        'sync_passwords' => false,
        'sync_attributes' => [
            'name' => 'cn',
            'email' => 'mail',
        ],
        'sync_existing' => [
            'email' => [
                'attribute' => 'mail',
                'operator' => 'ilike',
            ],
        ],
    ],
],
```

Move the original value of the array under the `attribute` key. This would fix #256 