### PR TITLE
Include PHP 8 in GitHub Action tests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -27,6 +27,8 @@ jobs:
                 exclude:
                   - laravel: 8.*
                     php: 7.2
+                  - laravel: 5.8.*
+                    php: 8.0
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,7 +12,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [7.4, 7.3, 7.2]
+                php: [8.0, 7.4, 7.3, 7.2]
                 laravel: [8.*, 7.*, 6.*, 5.8.*]
                 dependency-version: [prefer-stable]
                 include:


### PR DESCRIPTION
This PR does add tests against PHP 8 as well in GitHub Actions.