### PR TITLE
Make ldap config file publishable

### DIFF
--- a/src/LdapServiceProvider.php
+++ b/src/LdapServiceProvider.php
@@ -38,7 +38,7 @@ class LdapServiceProvider extends ServiceProvider
         if ($this->app->runningInConsole()) {
             $this->publishes([
                 __DIR__.'/../config/ldap.php' => config_path('ldap.php'),
-            ]);
+            ], 'ldap-config');
         }
     }
 


### PR DESCRIPTION
This little tweak does list the config file as publishable, if using the `php artisan vendor:publish` command. 

Right now, the LDAP providers are listed, but the config file isn't.


<img width="616" alt="Screenshot 2021-04-26 at 15 12 59" src="https://user-images.githubusercontent.com/38906163/116088432-27592b00-a6a2-11eb-91be-863b4f63f5fe.png">
