### PR TITLE
Allow Laravel Container to resolve the correct config/repository class

### DIFF
--- a/src/Commands/ImportLdapUsers.php
+++ b/src/Commands/ImportLdapUsers.php
@@ -2,8 +2,8 @@
 
 namespace LdapRecord\Laravel\Commands;
 
-Use Illuminate\Contracts\Config\Repository;
 use Illuminate\Console\Command;
+Use Illuminate\Contracts\Config\Repository;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Event;
 use LdapRecord\Laravel\Auth\DatabaseUserProvider;

--- a/src/Commands/ImportLdapUsers.php
+++ b/src/Commands/ImportLdapUsers.php
@@ -2,7 +2,7 @@
 
 namespace LdapRecord\Laravel\Commands;
 
-use Illuminate\Config\Repository;
+Use Illuminate\Contracts\Config\Repository;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Event;


### PR DESCRIPTION
I'm using orchestra platform, when calling ImportLdapUsers command I will have the following error.

"Argument 2 passed to LdapRecord\Laravel\Commands\ImportLdapUsers::handle() must be an instance of Illuminate\Config\Repository, instance of Orchestra\Config\Repository given, called in /home/vagrant/mobility/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php on line 36"

This changes will allow the command running without error.