### PR TITLE
Don't process models twice in emulated query

### DIFF
--- a/src/Testing/Emulated/EmulatesModelQueries.php
+++ b/src/Testing/Emulated/EmulatesModelQueries.php
@@ -109,6 +109,11 @@ trait EmulatesModelQueries
     protected function process(array $results)
     {
         return $this->model->newCollection($results)->transform(function ($object) {
+            // Don't process result again if it has already been processed
+            if ($object instanceof $this->model) {
+                return $object;
+            }
+
             return $this->model->newInstance()
                 ->setDn($object['dn'])
                 ->setRawAttributes(array_merge(

--- a/tests/Feature/Emulator/EmulatedModelQueryTest.php
+++ b/tests/Feature/Emulator/EmulatedModelQueryTest.php
@@ -493,6 +493,21 @@ class EmulatedModelQueryTest extends TestCase
         $this->assertCount(2, TestModelStub::in('ou=Users,dc=local,dc=com')->get());
     }
 
+    public function test_find_many()
+    {
+        $testModel1 = TestModelStub::create(['cn' => 'John']);
+        $testModel2 = TestModelStub::create(['cn' => 'Jane']);
+
+        $results = TestModelStub::findMany([
+            $testModel1->getDn(),
+            $testModel2->getDn(),
+        ]);
+
+        $this->assertCount(2, $results);
+        $this->assertTrue($testModel1->is($results[0]));
+        $this->assertTrue($testModel2->is($results[1]));
+    }
+
     public function test_find_by_anr()
     {
         TestModelStub::create(['cn' => 'John']);


### PR DESCRIPTION
## Description

This PR fixed a bug in the directory emulator where calling `Model::findMany` doest find the correct models, but all their attributes will be empty.

```php
$users = User::findMany([$dn1, $dn2]);
$users[0]->getDn();
// ""
```

From my tests, this doesn't seem to happen with any other method.

This bug happens because the `EmulatesQueries` trait implements `findMany` by essentially calling `find` in a loop. The bug happens because both `find` and `findMany` call `$this->process` on the found objects. The `EmulatesModelQueries` trait overrides the `process` method and tries to map the found records to model classes. The issue is that the implementation assumes that the results are arrays and tries to access the attributes accordingly. By the time `findMany` calls `$this->process` on the result set, all of the individual records have _already_ been processed as part of the `find` call.

This PR changes the implementation of the `EmulatesModelQueries::process` method to check if the object is already an instance of the target model class and simply returns it if that's the case. Otherwise it will process the record as before. 

I have also added a test case which reproduced the error.