### PR TITLE
Add ability to add query scopes to `LdapImporter` and `ldap:import` command

### DIFF
--- a/src/Auth/DatabaseUserProvider.php
+++ b/src/Auth/DatabaseUserProvider.php
@@ -14,6 +14,7 @@ use LdapRecord\Laravel\LdapUserAuthenticator;
 use LdapRecord\Laravel\LdapUserRepository;
 use LdapRecord\Models\Model;
 
+/** @mixin EloquentUserProvider */
 class DatabaseUserProvider extends UserProvider
 {
     use ForwardsCalls;

--- a/src/Commands/ImportLdapUsers.php
+++ b/src/Commands/ImportLdapUsers.php
@@ -27,15 +27,16 @@ class ImportLdapUsers extends Command
      *
      * @var string
      */
-    protected $signature = 'ldap:import {provider=ldap : The authentication provider to import.}
+    protected $signature = "ldap:import {provider=ldap : The authentication provider to import.}
             {user? : The specific user to import.}
-            {--f|filter= : The raw LDAP filter for limiting users imported.}
-            {--a|attributes= : Comma separated list of LDAP attributes to select. }
-            {--d|delete : Soft-delete the users model if their LDAP account is disabled.}
-            {--r|restore : Restores soft-deleted models if their LDAP account is enabled.}
-            {--c|chunk= : Use chunked based importing by specifying how many records per chunk.}
-            {--dm|delete-missing : Soft-delete all users that are missing from the import. }
-            {--no-log : Disables logging successful and unsuccessful imports.}';
+            {--f|filter= : A raw LDAP filter to apply to the LDAP query.}
+            {--s|scopes= : Comma seperated list of scopes to apply to the LDAP query.}
+            {--a|attributes= : Comma separated list of LDAP attributes to select.}
+            {--d|delete : Enable soft-deleting user models if their LDAP account is disabled.}
+            {--r|restore : Enable restoring soft-deleted user models if their LDAP account is enabled.}
+            {--c|chunk= : Enable chunked based importing by specifying how many records per chunk.}
+            {--dm|delete-missing : Enable soft-deleting all users that are missing from the import.}
+            {--no-log : Disable logging successful and unsuccessful imports.}";
 
     /**
      * The description of the console command.
@@ -249,6 +250,10 @@ class ImportLdapUsers extends Command
 
         if ($filter = $this->option('filter')) {
             $this->importer->setLdapRawFilter($filter);
+        }
+
+        if ($scopes = $this->option('scopes')) {
+            $this->importer->setLdapScopes(explode(',', $scopes));
         }
 
         if ($attributes = $this->option('attributes')) {

--- a/tests/Feature/Emulator/EmulatedImportTest.php
+++ b/tests/Feature/Emulator/EmulatedImportTest.php
@@ -320,7 +320,6 @@ class EmulatedImportTest extends DatabaseTestCase
         $this->setupDatabaseUserProvider([
             'database' => [
                 'model' => TestUserModelStub::class,
-                'sync_existing' => ['domain' => 'my-domain'],
             ],
         ]);
 

--- a/tests/Feature/Emulator/EmulatedImportTest.php
+++ b/tests/Feature/Emulator/EmulatedImportTest.php
@@ -11,6 +11,9 @@ use LdapRecord\Laravel\Tests\Feature\DatabaseTestCase;
 use LdapRecord\Laravel\Tests\Feature\TestUserModelStub;
 use LdapRecord\Models\ActiveDirectory\User;
 use LdapRecord\Models\Attributes\AccountControl;
+use LdapRecord\Models\Model;
+use LdapRecord\Models\Scope;
+use LdapRecord\Query\Model\Builder;
 
 class EmulatedImportTest extends DatabaseTestCase
 {
@@ -310,5 +313,46 @@ class EmulatedImportTest extends DatabaseTestCase
         $database->refresh();
 
         $this->assertEquals($user->getConvertedGuid(), $database->guid);
+    }
+
+    public function test_scopes_can_be_applied_to_command()
+    {
+        $this->setupDatabaseUserProvider([
+            'database' => [
+                'model' => TestUserModelStub::class,
+                'sync_existing' => ['domain' => 'my-domain'],
+            ],
+        ]);
+
+        DirectoryEmulator::setup();
+
+        User::create([
+            'cn' => 'Foo',
+            'mail' => $this->faker->email,
+            'objectguid' => $this->faker->uuid,
+        ]);
+
+        User::create([
+            'cn' => 'Bar',
+            'mail' => $this->faker->email,
+            'objectguid' => $this->faker->uuid,
+        ]);
+
+        $this->artisan('ldap:import', [
+            'provider' => 'ldap-database',
+            '--scopes' => TestImportUserModelScope::class,
+            '--no-interaction',
+        ])->assertExitCode(0);
+
+        $this->assertCount(1, $users = TestUserModelStub::get());
+        $this->assertEquals('Bar', $users->first()->name);
+    }
+}
+
+class TestImportUserModelScope implements Scope
+{
+    public function apply(Builder $query, Model $model)
+    {
+        return $query->where('cn', 'Bar');
     }
 }

--- a/tests/Unit/LdapImporterTest.php
+++ b/tests/Unit/LdapImporterTest.php
@@ -13,6 +13,9 @@ use LdapRecord\Laravel\LdapImportable;
 use LdapRecord\Laravel\Testing\DirectoryEmulator;
 use LdapRecord\Laravel\Tests\TestCase;
 use LdapRecord\Models\ActiveDirectory\Group as LdapGroup;
+use LdapRecord\Models\Scope;
+use LdapRecord\Models\Model as LdapModel;
+use LdapRecord\Query\Model\Builder;
 
 class LdapImporterTest extends TestCase
 {
@@ -69,6 +72,37 @@ class LdapImporterTest extends TestCase
 
         $this->assertCount(1, $imported);
         $this->assertEquals($object->getFirstAttribute('cn'), $imported->first()->name);
+    }
+
+    public function test_scopes_can_be_applied_to_import_query()
+    {
+        LdapGroup::create([
+            'objectguid' => $this->faker->uuid,
+            'cn' => 'First Group',
+        ]);
+
+        LdapGroup::create([
+            'objectguid' => $this->faker->uuid,
+            'cn' => 'Second Group',
+        ]);
+
+        $imported = (new Importer)
+            ->setLdapModel(LdapGroup::class)
+            ->setSyncAttributes(['name' => 'cn'])
+            ->setLdapScopes(TestImporterScopeStub::class)
+            ->setEloquentModel(TestImporterGroupModelStub::class)
+            ->execute();
+
+        $this->assertCount(1, $imported);
+        $this->assertEquals('Second Group', $imported->first()->name);
+    }
+}
+
+class TestImporterScopeStub implements Scope
+{
+    public function apply(Builder $query, LdapModel $model)
+    {
+        return $query->where('cn', 'Second Group');
     }
 }
 


### PR DESCRIPTION
**Command Usage**:

```bash
php artisan ldap:import --scopes="App\Ldap\Scopes\OnlyAccounting"
```

**Importer Usage**:

```php
$importer = (new LdapImporter)->setLdapScopes(
    \App\Ldap\Scopes\OnlyAccounting::class,
);
```