### PR TITLE
Fix ldap:browse command for V3 release

### DIFF
--- a/src/Commands/BrowseLdapServer.php
+++ b/src/Commands/BrowseLdapServer.php
@@ -173,7 +173,7 @@ class BrowseLdapServer extends Command
     {
         return $this->newLdapQuery()
             ->in($this->selectedDn)
-            ->listing()
+            ->list()
             ->paginate()
             ->sortBy(function (Model $object) {
                 return $object->getName();


### PR DESCRIPTION
This PR fixes the `php artisan ldap:browse` command for the V3 release of LdapRecord-Laravel.