### PR TITLE
Allow invokable classes and closures to be used in attribute handlers

### DIFF
--- a/src/Import/Hydrators/AttributeHydrator.php
+++ b/src/Import/Hydrators/AttributeHydrator.php
@@ -14,8 +14,6 @@ class AttributeHydrator extends Hydrator
     public function hydrate(LdapModel $object, EloquentModel $eloquent): void
     {
         foreach ($this->getSyncAttributes() as $eloquentField => $ldapField) {
-            ray($this->isAttributeHandler($ldapField));
-
             if ($this->isAttributeHandler($ldapField)) {
                 $handler = is_callable($ldapField) ? $ldapField : app($ldapField);
 

--- a/src/Import/Hydrators/AttributeHydrator.php
+++ b/src/Import/Hydrators/AttributeHydrator.php
@@ -56,7 +56,10 @@ class AttributeHydrator extends Hydrator
      */
     protected function isAttributeHandler(mixed $value): bool
     {
-        return is_callable($value) || class_exists($value)
-            && (method_exists($value, '__invoke') || method_exists($value, 'handle'));
+        if ($value instanceof Closure) {
+            return true;
+        }
+
+        return class_exists($value) && (method_exists($value, '__invoke') || method_exists($value, 'handle'));
     }
 }

--- a/src/Import/Hydrators/AttributeHydrator.php
+++ b/src/Import/Hydrators/AttributeHydrator.php
@@ -2,6 +2,7 @@
 
 namespace LdapRecord\Laravel\Import\Hydrators;
 
+use Closure;
 use Illuminate\Database\Eloquent\Model as EloquentModel;
 use Illuminate\Support\Arr;
 use LdapRecord\Models\Model as LdapModel;
@@ -14,22 +15,27 @@ class AttributeHydrator extends Hydrator
     public function hydrate(LdapModel $object, EloquentModel $eloquent): void
     {
         foreach ($this->getSyncAttributes() as $eloquentField => $ldapField) {
-            if ($this->isAttributeHandler($ldapField)) {
-                $handler = is_callable($ldapField) ? $ldapField : app($ldapField);
-
-                if (is_callable($handler)) {
-                    $handler($object, $eloquent);
-                    continue;
-                }
-
-                $handler->handle($object, $eloquent);
+            if (! $this->isAttributeHandler($ldapField)) {
+                $eloquent->{$eloquentField} = is_string($ldapField)
+                    ? $object->getFirstAttribute($ldapField)
+                    : $ldapField;
 
                 continue;
             }
 
-            $eloquent->{$eloquentField} = is_string($ldapField)
-                ? $object->getFirstAttribute($ldapField)
-                : $ldapField;
+            if ($ldapField instanceof Closure) {
+                $ldapField($object, $eloquent);
+
+                continue;
+            }
+
+            if (is_callable($handler = app($ldapField))) {
+                $handler($object, $eloquent);
+
+                continue;
+            }
+
+            $handler->handle($object, $eloquent);
         }
     }
 
@@ -41,20 +47,16 @@ class AttributeHydrator extends Hydrator
         return (array) Arr::get(
             $this->config,
             'sync_attributes',
-            $default = ['name' => 'cn', 'email' => 'mail']
+            ['name' => 'cn', 'email' => 'mail']
         );
     }
 
     /**
-     * Determines if the given handler value is a class that contains the 'handle' method.
+     * Determines if the given value is an attribute handler.
      */
-    protected function isAttributeHandler($handler): bool
+    protected function isAttributeHandler(mixed $value): bool
     {
-        if (is_callable($handler)) {
-            return true;
-        }
-
-        return is_string($handler) && class_exists($handler) &&
-            (method_exists($handler, 'handle') || method_exists($handler, '__invoke'));
+        return is_callable($value) || class_exists($value)
+            && (method_exists($value, '__invoke') || method_exists($value, 'handle'));
     }
 }

--- a/tests/Unit/EloquentHydratorTest.php
+++ b/tests/Unit/EloquentHydratorTest.php
@@ -48,6 +48,40 @@ class EloquentHydratorTest extends TestCase
         $this->assertEquals('baz', $model->foo);
     }
 
+    public function test_attribute_hydrator_can_use_handle_function_of_class()
+    {
+        $entry = new Entry(['bar' => 'baz']);
+        $model = new TestHydratorModelStub;
+        AttributeHydrator::with(['sync_attributes' => [TestAttributeHandlerHandleStub::class]])
+            ->hydrate($entry, $model);
+
+        $this->assertEquals('baz', $model->foo);
+    }
+
+    public function test_attribute_hydrator_can_use_invokable_class()
+    {
+        $entry = new Entry(['bar' => 'baz']);
+        $model = new TestHydratorModelStub;
+        AttributeHydrator::with(['sync_attributes' => [TestAttributeHandlerInvokableStub::class]])
+            ->hydrate($entry, $model);
+
+        $this->assertEquals('baz', $model->foo);
+    }
+
+    public function test_attribute_hydrator_can_use_inline_function()
+    {
+        $entry = new Entry(['bar' => 'baz']);
+        $model = new TestHydratorModelStub;
+        AttributeHydrator::with(['sync_attributes' => [
+                function ($object, $eloquent) {
+                    $eloquent->foo = $object->getFirstAttribute('bar');
+                }
+            ]])
+            ->hydrate($entry, $model);
+
+        $this->assertEquals('baz', $model->foo);
+    }
+
     public function test_password_hydrator_uses_random_password()
     {
         $entry = new Entry(['bar' => 'baz']);
@@ -115,4 +149,20 @@ class EloquentHydratorTest extends TestCase
 class TestHydratorModelStub extends Model implements LdapAuthenticatable
 {
     use AuthenticatesWithLdap;
+}
+
+class TestAttributeHandlerHandleStub
+{
+    public function handle($object, $eloquent)
+    {
+        $eloquent->foo = $object->getFirstAttribute('bar');
+    }
+}
+
+class TestAttributeHandlerInvokableStub
+{
+    public function __invoke($object, $eloquent)
+    {
+        $eloquent->foo = $object->getFirstAttribute('bar');
+    }
 }

--- a/tests/Unit/EloquentHydratorTest.php
+++ b/tests/Unit/EloquentHydratorTest.php
@@ -42,8 +42,10 @@ class EloquentHydratorTest extends TestCase
     {
         $entry = new Entry(['bar' => 'baz']);
         $model = new TestHydratorModelStub;
-        AttributeHydrator::with(['sync_attributes' => ['foo' => 'bar']])
-            ->hydrate($entry, $model);
+
+        AttributeHydrator::with([
+            'sync_attributes' => ['foo' => 'bar'],
+        ])->hydrate($entry, $model);
 
         $this->assertEquals('baz', $model->foo);
     }
@@ -52,8 +54,10 @@ class EloquentHydratorTest extends TestCase
     {
         $entry = new Entry(['bar' => 'baz']);
         $model = new TestHydratorModelStub;
-        AttributeHydrator::with(['sync_attributes' => [TestAttributeHandlerHandleStub::class]])
-            ->hydrate($entry, $model);
+
+        AttributeHydrator::with([
+            'sync_attributes' => [TestAttributeHandlerHandleStub::class],
+        ])->hydrate($entry, $model);
 
         $this->assertEquals('baz', $model->foo);
     }
@@ -62,8 +66,10 @@ class EloquentHydratorTest extends TestCase
     {
         $entry = new Entry(['bar' => 'baz']);
         $model = new TestHydratorModelStub;
-        AttributeHydrator::with(['sync_attributes' => [TestAttributeHandlerInvokableStub::class]])
-            ->hydrate($entry, $model);
+
+        AttributeHydrator::with(['sync_attributes' => [
+            TestAttributeHandlerInvokableStub::class,
+        ]])->hydrate($entry, $model);
 
         $this->assertEquals('baz', $model->foo);
     }
@@ -72,12 +78,12 @@ class EloquentHydratorTest extends TestCase
     {
         $entry = new Entry(['bar' => 'baz']);
         $model = new TestHydratorModelStub;
+
         AttributeHydrator::with(['sync_attributes' => [
-                function ($object, $eloquent) {
-                    $eloquent->foo = $object->getFirstAttribute('bar');
-                }
-            ]])
-            ->hydrate($entry, $model);
+            function ($object, $eloquent) {
+                $eloquent->foo = $object->getFirstAttribute('bar');
+            },
+        ]])->hydrate($entry, $model);
 
         $this->assertEquals('baz', $model->foo);
     }


### PR DESCRIPTION
This is just a quality-of-life improvement for configuring attribute handlers. This PR allows you to define invokable classes and inline closures as attribute handlers.

If this gets merged I will also update the docs. Thanks! 💯 