### PR TITLE
Returned value from ldap:test is error if connection is not successfull

### DIFF
--- a/src/Commands/TestLdapConnection.php
+++ b/src/Commands/TestLdapConnection.php
@@ -44,14 +44,16 @@ class TestLdapConnection extends Command
         }
 
         $tested = [];
+        $rv = 0;
 
         foreach ($connections as $name => $connection) {
             $tested[] = $this->performTest($name, $connection);
+            $rv += $connection->isConnected() ? static::SUCCESS : static::FAILURE;
         }
 
         $this->table(['Connection', 'Successful', 'Username', 'Message', 'Response Time'], $tested);
 
-        return static::SUCCESS;
+        return $rv;
     }
 
     /**


### PR DESCRIPTION
In case of connection problem command `php artisan ldap:test` should return error:

    $ php artisan ldap:test ; echo $?
    Testing LDAP connection [default]...
    +------------+------------+----------------------------+-----------------------------------------------------------+---------------+
    | Connection | Successful | Username                   | Message                                                   | Response Time |
    +------------+------------+----------------------------+-----------------------------------------------------------+---------------+
    | default    | ✘ No       | cn=admin,dc=example,dc=com | No such object. Error Code: [32] Diagnostic Message: null | 772.8ms       |
    +------------+------------+----------------------------+-----------------------------------------------------------+---------------+
    1

    $ php artisan ldap:test ; echo $?
    Testing LDAP connection [default]...
    +------------+------------+----------------------------+-------------------------+---------------+
    | Connection | Successful | Username                   | Message                 | Response Time |
    +------------+------------+----------------------------+-------------------------+---------------+
    | default    | ✔ Yes      | cn=admin,dc=example,dc=com | Successfully connected. | 1001.81ms     |
    +------------+------------+----------------------------+-------------------------+---------------+
    0