### PR TITLE
Emulate `memberof` virtual attribute in Directory Emulator

### DIFF
--- a/src/Testing/EmulatesQueries.php
+++ b/src/Testing/EmulatesQueries.php
@@ -299,14 +299,18 @@ trait EmulatesQueries
                 }
                 break;
             case LDAP_MODIFY_BATCH_REPLACE:
-                $attribute->values()->delete();
+                $attribute->values()->each(
+                    fn (LdapObjectAttributeValue $value) => $value->delete()
+                );
 
                 foreach ($values as $value) {
                     $attribute->values()->create(['value' => $value]);
                 }
                 break;
             case LDAP_MODIFY_BATCH_REMOVE:
-                $attribute->values()->whereIn('value', $values)->delete();
+                $attribute->values()->whereIn('value', $values)->each(
+                    fn (LdapObjectAttributeValue $value) => $value->delete()
+                );
                 break;
             case LDAP_MODIFY_BATCH_REMOVE_ALL:
                 $attribute->delete();
@@ -424,7 +428,9 @@ trait EmulatesQueries
                 'name' => $this->normalizeAttributeName($name),
             ]);
 
-            $attribute->values()->delete();
+            $attribute->values()->each(
+                fn (LdapObjectAttributeValue $value) => $value->delete()
+            );
 
             foreach ((array) $values as $value) {
                 $attribute->values()->create(['value' => $value]);

--- a/src/Testing/EmulatesQueries.php
+++ b/src/Testing/EmulatesQueries.php
@@ -139,7 +139,7 @@ trait EmulatesQueries
      */
     public function findEloquentModelByDn(string $dn): ?LdapObject
     {
-        return $this->newEloquentQuery()->firstWhere('dn', 'like', $dn);
+        return $this->newEloquentModel()->findByDn($dn);
     }
 
     /**
@@ -147,7 +147,7 @@ trait EmulatesQueries
      */
     public function findEloquentModelByGuid(string $guid): ?LdapObject
     {
-        return $this->newEloquentQuery()->firstWhere('guid', '=', $guid);
+        return $this->newEloquentModel()->findByGuid($guid);
     }
 
     /**

--- a/src/Testing/LdapObject.php
+++ b/src/Testing/LdapObject.php
@@ -40,7 +40,7 @@ class LdapObject extends Model
      */
     public static function booted(): void
     {
-        static::observe(VirtualObjectObserver::class);
+        static::observe(VirtualAttributeObserver::class);
     }
 
     /**

--- a/src/Testing/LdapObject.php
+++ b/src/Testing/LdapObject.php
@@ -36,6 +36,30 @@ class LdapObject extends Model
     protected $with = ['attributes'];
 
     /**
+     * Register the virtual object observer.
+     */
+    public static function booted(): void
+    {
+        static::observe(VirtualObjectObserver::class);
+    }
+
+    /**
+     * Find an object by its distinguished name.
+     */
+    public static function findByDn(string $dn): ?static
+    {
+        return static::firstWhere('dn', 'like', $dn);
+    }
+
+    /**
+     * Find an object by its object guid.
+     */
+    public static function findByGuid(string $guid): ?static
+    {
+        return static::firstWhere('guid', '=', $guid);
+    }
+
+    /**
      * The hasMany attributes relation.
      */
     public function attributes(): HasMany

--- a/src/Testing/LdapObjectAttribute.php
+++ b/src/Testing/LdapObjectAttribute.php
@@ -3,12 +3,14 @@
 namespace LdapRecord\Laravel\Testing;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 /**
  * @property int $id
  * @property int $ldap_object_id
  * @property string $name
+ * @property LdapObject $object
  * @property \Illuminate\Database\Eloquent\Collection $values
  */
 class LdapObjectAttribute extends Model
@@ -43,14 +45,24 @@ class LdapObjectAttribute extends Model
     {
         parent::boot();
 
-        static::deleted(function ($model) {
+        static::deleting(function (self $model) {
             // Delete the attribute values when deleted.
-            $model->values()->delete();
+            $model->values()->each(
+                fn (LdapObjectAttributeValue $value) => $value->delete()
+            );
         });
     }
 
     /**
-     * The hasMany values relation.
+     * The object relationship.
+     */
+    public function object(): BelongsTo
+    {
+        return $this->belongsTo(LdapObject::class, 'ldap_object_id');
+    }
+
+    /**
+     * The values relationship.
      */
     public function values(): HasMany
     {

--- a/src/Testing/LdapObjectAttributeValue.php
+++ b/src/Testing/LdapObjectAttributeValue.php
@@ -3,11 +3,13 @@
 namespace LdapRecord\Laravel\Testing;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
  * @property int $id
  * @property int $ldap_object_attribute_id
  * @property string $value
+ * @property LdapObjectAttribute $attribute
  */
 class LdapObjectAttributeValue extends Model
 {
@@ -26,4 +28,20 @@ class LdapObjectAttributeValue extends Model
      * @var bool
      */
     public $timestamps = false;
+
+    /**
+     * Register the virtual attribute observer.
+     */
+    protected static function booted(): void
+    {
+        static::observe(VirtualAttributeValueObserver::class);
+    }
+
+    /**
+     * The attribute relationship.
+     */
+    public function attribute(): BelongsTo
+    {
+        return $this->belongsTo(LdapObjectAttribute::class, 'ldap_object_attribute_id');
+    }
 }

--- a/src/Testing/VirtualAttributeObserver.php
+++ b/src/Testing/VirtualAttributeObserver.php
@@ -4,16 +4,13 @@ namespace LdapRecord\Laravel\Testing;
 
 use Illuminate\Database\Eloquent\Builder;
 
-class VirtualObjectObserver
+class VirtualAttributeObserver
 {
     /**
-     * The virtual attributes to observe.
+     * The attributes to and update when changed.
      */
-    protected array $attributes = [
-        'dn' => [
-            'member',
-            'memberof',
-        ],
+    public static array $attributes = [
+        'dn' => ['member', 'memberof'],
     ];
 
     /**
@@ -25,7 +22,7 @@ class VirtualObjectObserver
             return;
         }
 
-        foreach ($this->attributes as $property => $attributes) {
+        foreach (static::$attributes as $property => $attributes) {
             if (! array_key_exists($property, $changes)) {
                 continue;
             }

--- a/src/Testing/VirtualAttributeValueObserver.php
+++ b/src/Testing/VirtualAttributeValueObserver.php
@@ -5,9 +5,9 @@ namespace LdapRecord\Laravel\Testing;
 class VirtualAttributeValueObserver
 {
     /**
-     * The virtual attributes to emulate.
+     * The virtual attributes to update when changed.
      */
-    protected array $attributes = [
+    public static array $attributes = [
         'member' => 'memberof',
     ];
 
@@ -27,7 +27,7 @@ class VirtualAttributeValueObserver
 
         /** @var LdapObjectAttribute $attribute */
         $attribute = $object->attributes()->firstOrCreate([
-            'name' => $this->attributes[$model->attribute->name],
+            'name' => static::$attributes[$model->attribute->name],
         ]);
 
         $attribute->values()->firstOrCreate([
@@ -50,7 +50,7 @@ class VirtualAttributeValueObserver
         }
 
         /** @var LdapObjectAttribute|null $attribute */
-        if (! $attribute = $object->attributes()->firstWhere('name', $this->attributes[$model->attribute->name])) {
+        if (! $attribute = $object->attributes()->firstWhere('name', static::$attributes[$model->attribute->name])) {
             return;
         }
 
@@ -62,6 +62,6 @@ class VirtualAttributeValueObserver
      */
     protected function hasVirtualAttribute(string $attribute): bool
     {
-        return array_key_exists($attribute, $this->attributes);
+        return array_key_exists($attribute, static::$attributes);
     }
 }

--- a/src/Testing/VirtualAttributeValueObserver.php
+++ b/src/Testing/VirtualAttributeValueObserver.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace LdapRecord\Laravel\Testing;
+
+class VirtualAttributeValueObserver
+{
+    /**
+     * The virtual attributes to emulate.
+     */
+    protected array $attributes = [
+        'member' => 'memberof',
+    ];
+
+    /**
+     * Handle updating the virtual attribute in the related model.
+     */
+    public function saving(LdapObjectAttributeValue $model): void
+    {
+        if (! $this->hasVirtualAttribute($model->attribute->name)) {
+            return;
+        }
+
+        /** @var LdapObject|null $object */
+        if (! $object = LdapObject::findByDn($model->value)) {
+            return;
+        }
+
+        /** @var LdapObjectAttribute $attribute */
+        $attribute = $object->attributes()->firstOrCreate([
+            'name' => $this->attributes[$model->attribute->name],
+        ]);
+
+        $attribute->values()->firstOrCreate([
+            'value' => $model->attribute->object->dn,
+        ]);
+    }
+
+    /**
+     * Handle deleting the virtual attribute in the related model.
+     */
+    public function deleting(LdapObjectAttributeValue $model): void
+    {
+        if (! $this->hasVirtualAttribute($model->attribute->name)) {
+            return;
+        }
+
+        /** @var LdapObject|null $object */
+        if (! $object = LdapObject::findByDn($model->value)) {
+            return;
+        }
+
+        /** @var LdapObjectAttribute|null $attribute */
+        if (! $attribute = $object->attributes()->firstWhere('name', $this->attributes[$model->attribute->name])) {
+            return;
+        }
+
+        $attribute->values()->where('value', $model->attribute->object->dn)->delete();
+    }
+
+    /**
+     * Determine if a virtual attribute exists for the given attribute.
+     */
+    protected function hasVirtualAttribute(string $attribute): bool
+    {
+        return array_key_exists($attribute, $this->attributes);
+    }
+}

--- a/src/Testing/VirtualObjectObserver.php
+++ b/src/Testing/VirtualObjectObserver.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace LdapRecord\Laravel\Testing;
+
+use Illuminate\Database\Eloquent\Builder;
+
+class VirtualObjectObserver
+{
+    /**
+     * The virtual attributes to observe.
+     */
+    protected array $attributes = [
+        'dn' => [
+            'member',
+            'memberof',
+        ],
+    ];
+
+    /**
+     * Handle updating the virtual attribute values in related models.
+     */
+    public function updated(LdapObject $model): void
+    {
+        if (empty($changes = $model->getChanges())) {
+            return;
+        }
+
+        foreach ($this->attributes as $property => $attributes) {
+            if (! array_key_exists($property, $changes)) {
+                continue;
+            }
+
+            LdapObjectAttributeValue::query()
+                ->where('value', $model->getOriginal($property))
+                ->whereHas('attribute', fn (Builder $query) => $query->whereIn('name', $attributes))
+                ->each(fn (LdapObjectAttributeValue $value) => $value->update(['value' => $changes[$property]]));
+        }
+    }
+}

--- a/tests/Feature/Emulator/EmulatedModelQueryTest.php
+++ b/tests/Feature/Emulator/EmulatedModelQueryTest.php
@@ -587,7 +587,7 @@ class EmulatedModelQueryTest extends TestCase
     public function test_has_many_relationship()
     {
         $group = Group::create(['cn' => 'Accounting']);
-        $user = User::create(['cn' => 'John', 'memberof' => [$group->getDn()]]);
+        $user = User::create(['cn' => 'John']);
 
         $user->groups()->attach($group);
 
@@ -607,6 +607,50 @@ class EmulatedModelQueryTest extends TestCase
 
         $this->assertFalse($user->groups()->exists($group));
         $this->assertFalse($group->members()->exists($user));
+    }
+
+    public function test_rename_has_many_relationship()
+    {
+        $group = Group::create(['cn' => 'Accounting']);
+        $user = User::create(['cn' => 'John']);
+
+        $user->groups()->attach($group);
+
+        $this->assertEquals($user->getDn(), $group->getFirstAttribute('member'));
+
+        $this->assertTrue($user->is($group->members()->first()));
+        $this->assertTrue($group->is($user->groups()->first()));
+
+        $this->assertTrue($user->groups()->exists($group));
+        $this->assertTrue($group->members()->exists($user));
+
+        $group->rename('Personnel');
+
+        $this->assertEquals($user->getDn(), $group->getFirstAttribute('member'));
+
+        $this->assertTrue($user->is($group->members()->first()));
+        $this->assertTrue($group->is($user->groups()->first()));
+
+        $this->assertTrue($user->groups()->exists($group));
+        $this->assertTrue($group->members()->exists($user));
+    }
+
+    public function test_associate_has_many_relationship()
+    {
+        $group = Group::create(['cn' => 'Accounting']);
+        $user1 = User::create(['cn' => 'John']);
+        $user2 = User::create(['cn' => 'Jane']);
+
+        $group->members()->associate([$user1, $user2]);
+        $group->save();
+
+        $this->assertEquals(2, $group->members()->count());
+
+        $this->assertTrue($user1->groups()->exists($group));
+        $this->assertTrue($group->members()->exists($user1));
+
+        $this->assertTrue($user2->groups()->exists($group));
+        $this->assertTrue($group->members()->exists($user2));
     }
 
     public function test_has_one_relationship()

--- a/tests/Feature/Emulator/EmulatedModelQueryTest.php
+++ b/tests/Feature/Emulator/EmulatedModelQueryTest.php
@@ -626,8 +626,6 @@ class EmulatedModelQueryTest extends TestCase
 
         $group->rename('Personnel');
 
-        $this->assertEquals($user->getDn(), $group->getFirstAttribute('member'));
-
         $this->assertTrue($user->is($group->members()->first()));
         $this->assertTrue($group->is($user->groups()->first()));
 

--- a/tests/Feature/Emulator/EmulatedModelQueryTest.php
+++ b/tests/Feature/Emulator/EmulatedModelQueryTest.php
@@ -626,6 +626,8 @@ class EmulatedModelQueryTest extends TestCase
 
         $group->rename('Personnel');
 
+        $this->assertEquals("cn=Personnel,{$group->getBaseDn()}", $group->getDn());
+
         $this->assertTrue($user->is($group->members()->first()));
         $this->assertTrue($group->is($user->groups()->first()));
 


### PR DESCRIPTION
Closes https://github.com/DirectoryTree/LdapRecord-Laravel/issues/561
Closes https://github.com/DirectoryTree/LdapRecord-Laravel/pull/565

This PR implements emulating virtual attributes (`memberof` only right now) in the Directory Emulator. More attributes can be added if necessary by developers using the public attribute arrays inside of each observer.

This fixes the issue namely with attaching/detaching user groups and having the changes automatically reflected in the related models virtual attribute. This now works as it would with a real LDAP server. For example:

```php
use LdapRecord\Models\ActiveDirectory\User;
use LdapRecord\Models\ActiveDirectory\Group;

$user = User::create(['cn' => 'John']);
$group = Group::create(['cn' => 'Accounting']);

$user->groups()->attach($group);

$user->refresh();

dd($user->memberof); // ["cn=Accounting,dc=local,dc=com"]
```

This also fixes an issue where a model is renamed in the Directory Emulator, but the rename didn't update in relationships it's apart of.

Huge kudos and credit goes to @cheesegrits for this, as this is all inspired from his original PR https://github.com/DirectoryTree/LdapRecord-Laravel/pull/565.