### PR TITLE
Bug 602 - LoginController::causedByInvalidCredentials(): Argument DirectoryTree/LdapRecord#2 ($diagnosticMessage) must be of type string #602

### DIFF
--- a/src/Auth/ListensForLdapBindFailure.php
+++ b/src/Auth/ListensForLdapBindFailure.php
@@ -72,6 +72,13 @@ trait ListensForLdapBindFailure
                 $this->handleLdapBindError($errorMessage);
 
                 return;
+
+            case is_null($diagnosticMessage):
+                // If there is no diagnostic message to work with, we
+                // cannot make any further attempts to determine
+                // the error. We will bail here in such case.
+                return;
+
             case $this->causedByInvalidCredentials($errorMessage, $diagnosticMessage):
                 // We'll bypass any invalid LDAP credential errors and let
                 // the login controller handle it. This is so proper

--- a/tests/Unit/ListenForLdapBindFailureTest.php
+++ b/tests/Unit/ListenForLdapBindFailureTest.php
@@ -41,6 +41,7 @@ class ListenForLdapBindFailureTest extends TestCase
 
         /** @var \LdapRecord\Testing\LdapFake $ldap */
         $ldap = $fake->getLdapConnection();
+        $ldap->shouldReturnDiagnosticMessage(null);
         $ldap->shouldReturnError('Invalid credentials');
 
         $this->assertFalse($fake->auth()->attempt('user', 'secret'));


### PR DESCRIPTION
Closes #602 