### PR TITLE
Update LdapAuthServiceProvider.php

### DIFF
--- a/src/LdapAuthServiceProvider.php
+++ b/src/LdapAuthServiceProvider.php
@@ -63,6 +63,7 @@ class LdapAuthServiceProvider extends ServiceProvider
 
         Auth::provider('eloquent', function ($app, array $config) {
             $config = $this->swapLdapConfig($config);
+
             return array_key_exists('ldap', $config)
                 ? $this->makeDatabaseUserProvider($config)
                 : $this->makeEloquentUserProvider($config);

--- a/src/LdapAuthServiceProvider.php
+++ b/src/LdapAuthServiceProvider.php
@@ -61,11 +61,13 @@ class LdapAuthServiceProvider extends ServiceProvider
                 : $this->makePlainUserProvider($config);
         });
 
-        Auth::provider('eloquent', function ($app, array $config) {
-            return array_key_exists('ldap', $config)
-                ? $this->makeDatabaseUserProvider($this->swapLdapConfig($config))
-                : $this->makeEloquentUserProvider($config);
-        });
+        if (config('ldap.eloquent_overload', false)) {
+            Auth::provider('eloquent', function ($app, array $config) {
+                return array_key_exists('ldap', $config)
+                    ? $this->makeDatabaseUserProvider($this->swapLdapConfig($config))
+                    : $this->makeEloquentUserProvider($config);
+            });
+        }
     }
 
     /**

--- a/src/LdapAuthServiceProvider.php
+++ b/src/LdapAuthServiceProvider.php
@@ -60,6 +60,28 @@ class LdapAuthServiceProvider extends ServiceProvider
                 ? $this->makeDatabaseUserProvider($config)
                 : $this->makePlainUserProvider($config);
         });
+
+        Auth::provider('eloquent', function ($app, array $config) {
+            $config = $this->swapLdapConfig($config);
+            return array_key_exists('ldap', $config)
+                ? $this->makeDatabaseUserProvider($config)
+                : $this->makeEloquentUserProvider($config);
+        });
+    }
+
+    /**
+     * Swap config vars for alternative auth config.
+     */
+    protected function swapLdapConfig(array $config): array
+    {
+        // swap the Eloquent model with the Ldap model
+        [$config['model'], $config['ldap']['model']] = [$config['ldap']['model'], $config['model']];
+
+        // swap the config data key and remove the unused key
+        $config['database'] = $config['ldap'];
+        unset($config['ldap']);
+
+        return $config;
     }
 
     /**

--- a/src/LdapAuthServiceProvider.php
+++ b/src/LdapAuthServiceProvider.php
@@ -62,10 +62,8 @@ class LdapAuthServiceProvider extends ServiceProvider
         });
 
         Auth::provider('eloquent', function ($app, array $config) {
-            $config = $this->swapLdapConfig($config);
-
             return array_key_exists('ldap', $config)
-                ? $this->makeDatabaseUserProvider($config)
+                ? $this->makeDatabaseUserProvider($this->swapLdapConfig($config))
                 : $this->makeEloquentUserProvider($config);
         });
     }


### PR DESCRIPTION
Hi @stevebauman,

With regards to our discussion in https://github.com/DirectoryTree/LdapRecord-Laravel/discussions/341 I have come up with this idea.

This PR will allow users to use the following Ldap Auth config:

```
'driver' => 'eloquent',
'model' => App\Models\User::class,
'ldap' => [
    'model' => LdapRecord\Models\ActiveDirectory\User::class,
    'sync_passwords' => true,
    'sync_attributes' => [...]
], // ldap config here
```

With this config, Nova will simply use this as the regular Eloquent provider ignoring the 'ldap' config.

However, the app itself will recognize the 'ldap' config and swap the config in order to register the correct providers.

This approach is also backwards compatible.

The only thing that probably wouldn't work is utilizing this config setting in an app that needs both Ldap as well as Eloquent auth in the same request. However, I think that is very unlikely.

This fixes the issues with Nova and is a totally optional config setting. If the 'ldap' key is not set, a regular Eloquent Provider will be returned and everything will be as expected.

I am looking forward to your input and thoughts on this.