### PR TITLE
fix: use float type hint for $start parameter in getElapsedTime()

### DIFF
--- a/src/Commands/TestLdapConnection.php
+++ b/src/Commands/TestLdapConnection.php
@@ -111,7 +111,7 @@ class TestLdapConnection extends Command
     /**
      * Get the elapsed time since a given starting point.
      */
-    protected function getElapsedTime(int $start): int|float
+    protected function getElapsedTime(float $start): int|float
     {
         return round((microtime(true) - $start) * 1000, 2);
     }


### PR DESCRIPTION
`microtime(true)` returns a `float`, but `getElapsedTime()` declares `$start` as `int`.

In PHP 8.1+ this triggers a deprecation warning: `Implicit conversion from float 1779282680.57703 to int loses precision in /var/www/html/vendor/directorytree/ldaprecord-laravel/src/Commands/TestLdapConnection.php on line 114` 