### PR TITLE
Fix directory emulator chunking

### DIFF
--- a/src/Testing/EmulatedBuilder.php
+++ b/src/Testing/EmulatedBuilder.php
@@ -2,12 +2,24 @@
 
 namespace LdapRecord\Laravel\Testing;
 
+use Generator;
 use Illuminate\Support\Arr;
 use LdapRecord\Query\Builder;
 
 class EmulatedBuilder extends Builder
 {
     use EmulatesQueries;
+
+    /**
+     * Runs the chunk operation with the given filter.
+     */
+    protected function runChunk(string $filter, int $perPage, bool $isCritical): Generator
+    {
+        yield from array_chunk(
+            $this->parse($this->run($filter)),
+            $perPage
+        );
+    }
 
     /**
      * Process the database query results into an LDAP result set.

--- a/src/Testing/EmulatedConnectionFake.php
+++ b/src/Testing/EmulatedConnectionFake.php
@@ -27,6 +27,17 @@ class EmulatedConnectionFake extends ConnectionFake
     }
 
     /**
+     * Clone the connection.
+     */
+    public function replicate(): static
+    {
+        $replica = parent::replicate()->shouldBeConnected();
+        $replica->name = $this->name;
+
+        return $replica;
+    }
+
+    /**
      * Create a new Eloquent LDAP query builder.
      *
      * @throws ConfigurationException

--- a/tests/Feature/Emulator/EmulatedModelQueryTest.php
+++ b/tests/Feature/Emulator/EmulatedModelQueryTest.php
@@ -601,6 +601,84 @@ class EmulatedModelQueryTest extends TestCase
         $this->assertCount(2, TestModelStub::paginate());
     }
 
+    public function test_chunk()
+    {
+        TestModelStub::create(['cn' => 'John']);
+        TestModelStub::create(['cn' => 'Jane']);
+        TestModelStub::create(['cn' => 'Bob']);
+
+        $chunks = [];
+
+        $result = TestModelStub::chunk(2, function ($models) use (&$chunks) {
+            $chunks[] = $models;
+        });
+
+        $this->assertTrue($result);
+        $this->assertCount(2, $chunks);
+        $this->assertCount(2, $chunks[0]);
+        $this->assertCount(1, $chunks[1]);
+    }
+
+    public function test_chunk_can_be_isolated()
+    {
+        TestModelStub::create(['cn' => 'John']);
+        TestModelStub::create(['cn' => 'Jane']);
+        TestModelStub::create(['cn' => 'Bob']);
+
+        $chunks = [];
+
+        $result = TestModelStub::chunk(2, function ($models) use (&$chunks) {
+            $chunks[] = $models;
+        }, isolate: true);
+
+        $this->assertTrue($result);
+        $this->assertCount(2, $chunks);
+        $this->assertCount(2, $chunks[0]);
+        $this->assertCount(1, $chunks[1]);
+    }
+
+    public function test_isolated_chunk_uses_model_connection()
+    {
+        Container::addConnection(new Connection([
+            'base_dn' => 'dc=foo,dc=com',
+        ]), 'foo');
+
+        DirectoryEmulator::setup('foo');
+
+        TestModelStubWithFooConnection::create(['cn' => 'John']);
+        TestModelStubWithFooConnection::create(['cn' => 'Jane']);
+        TestModelStubWithFooConnection::create(['cn' => 'Bob']);
+
+        $chunks = [];
+
+        $result = TestModelStubWithFooConnection::chunk(2, function ($models) use (&$chunks) {
+            $chunks[] = $models;
+        }, isolate: true);
+
+        $this->assertTrue($result);
+        $this->assertCount(2, $chunks);
+        $this->assertCount(2, $chunks[0]);
+        $this->assertCount(1, $chunks[1]);
+    }
+
+    public function test_chunk_stops_when_callback_returns_false()
+    {
+        TestModelStub::create(['cn' => 'John']);
+        TestModelStub::create(['cn' => 'Jane']);
+        TestModelStub::create(['cn' => 'Bob']);
+
+        $callbacks = 0;
+
+        $result = TestModelStub::chunk(2, function () use (&$callbacks) {
+            $callbacks++;
+
+            return false;
+        });
+
+        $this->assertFalse($result);
+        $this->assertSame(1, $callbacks);
+    }
+
     public function test_has_many_relationship()
     {
         $group = Group::create(['cn' => 'Accounting']);


### PR DESCRIPTION
## Summary

Fix chunked model queries when using the directory emulator.

- Split emulated query results into chunks using the requested page size.
- Keep isolated connection replicas connected to the emulator.
- Preserve the emulated connection name when creating a replica.
- Cover regular chunking, isolated chunking, named connections, and early termination.

## Background

The directory emulator inherited the regular LDAP lazy paginator even though it does not emulate paged-results controls. As a result, non-isolated chunk queries returned the complete result set in a single callback and ignored the requested page size.

When isolation was enabled, the replicated connection received a fresh `LdapFake` that was not marked as connected. Its first query attempted an unexpected bind and failed.

The emulator now slices its in-memory result set directly. Isolated replicas are marked as connected and retain the original connection name.

## Impact

Applications can exercise the same `chunk()` and `each()` paths in emulator-backed tests that they use against a real LDAP server, including isolated queries and models using named connections.

Closes #709