### PR TITLE
Preserve directory emulator connections during isolated chunks

### DIFF
--- a/src/Testing/EmulatedConnectionFake.php
+++ b/src/Testing/EmulatedConnectionFake.php
@@ -32,6 +32,7 @@ class EmulatedConnectionFake extends ConnectionFake
     public function replicate(): static
     {
         $replica = parent::replicate()->shouldBeConnected();
+
         $replica->name = $this->name;
 
         return $replica;

--- a/src/Testing/EmulatedConnectionFake.php
+++ b/src/Testing/EmulatedConnectionFake.php
@@ -27,6 +27,17 @@ class EmulatedConnectionFake extends ConnectionFake
     }
 
     /**
+     * Clone the connection.
+     */
+    public function replicate(): static
+    {
+        $replica = parent::replicate()->shouldBeConnected();
+        $replica->name = $this->name;
+
+        return $replica;
+    }
+
+    /**
      * Create a new Eloquent LDAP query builder.
      *
      * @throws ConfigurationException

--- a/tests/Feature/Emulator/EmulatedModelQueryTest.php
+++ b/tests/Feature/Emulator/EmulatedModelQueryTest.php
@@ -601,6 +601,44 @@ class EmulatedModelQueryTest extends TestCase
         $this->assertCount(2, TestModelStub::paginate());
     }
 
+    public function test_chunk_can_be_isolated()
+    {
+        $model = TestModelStub::create(['cn' => 'John']);
+
+        $chunks = [];
+
+        $result = TestModelStub::chunk(100, function ($models) use (&$chunks) {
+            $chunks[] = $models;
+        }, isolate: true);
+
+        $this->assertTrue($result);
+        $this->assertCount(1, $chunks);
+        $this->assertCount(1, $chunks[0]);
+        $this->assertTrue($model->is($chunks[0]->first()));
+    }
+
+    public function test_isolated_chunk_uses_model_connection()
+    {
+        Container::addConnection(new Connection([
+            'base_dn' => 'dc=foo,dc=com',
+        ]), 'foo');
+
+        DirectoryEmulator::setup('foo');
+
+        $model = TestModelStubWithFooConnection::create(['cn' => 'John']);
+
+        $chunks = [];
+
+        $result = TestModelStubWithFooConnection::chunk(100, function ($models) use (&$chunks) {
+            $chunks[] = $models;
+        }, isolate: true);
+
+        $this->assertTrue($result);
+        $this->assertCount(1, $chunks);
+        $this->assertCount(1, $chunks[0]);
+        $this->assertTrue($model->is($chunks[0]->first()));
+    }
+
     public function test_has_many_relationship()
     {
         $group = Group::create(['cn' => 'Accounting']);


### PR DESCRIPTION
## Summary

Allow directory-emulator model chunks to use isolated connections.

Emulated connection replicas are now marked as connected and retain the original emulator connection name.

## Root cause

`Connection::isolate()` creates a replica through `Connection::replicate()`. The inherited implementation constructs a fresh `LdapFake` that is not marked as connected, so its first query attempts an unexpected bind.

The inherited replica also loses the emulator connection name. Models configured to use a named connection can therefore query the wrong emulated database.

Part of #709