### PR TITLE
Respect chunk sizes in the directory emulator

### DIFF
--- a/src/Testing/EmulatedBuilder.php
+++ b/src/Testing/EmulatedBuilder.php
@@ -2,12 +2,24 @@
 
 namespace LdapRecord\Laravel\Testing;
 
+use Generator;
 use Illuminate\Support\Arr;
 use LdapRecord\Query\Builder;
 
 class EmulatedBuilder extends Builder
 {
     use EmulatesQueries;
+
+    /**
+     * Runs the chunk operation with the given filter.
+     */
+    protected function runChunk(string $filter, int $perPage, bool $isCritical): Generator
+    {
+        yield from array_chunk(
+            $this->parse($this->run($filter)),
+            $perPage
+        );
+    }
 
     /**
      * Process the database query results into an LDAP result set.

--- a/tests/Feature/Emulator/EmulatedModelQueryTest.php
+++ b/tests/Feature/Emulator/EmulatedModelQueryTest.php
@@ -601,6 +601,42 @@ class EmulatedModelQueryTest extends TestCase
         $this->assertCount(2, TestModelStub::paginate());
     }
 
+    public function test_chunk()
+    {
+        TestModelStub::create(['cn' => 'John']);
+        TestModelStub::create(['cn' => 'Jane']);
+        TestModelStub::create(['cn' => 'Bob']);
+
+        $chunks = [];
+
+        $result = TestModelStub::chunk(2, function ($models) use (&$chunks) {
+            $chunks[] = $models;
+        });
+
+        $this->assertTrue($result);
+        $this->assertCount(2, $chunks);
+        $this->assertCount(2, $chunks[0]);
+        $this->assertCount(1, $chunks[1]);
+    }
+
+    public function test_chunk_stops_when_callback_returns_false()
+    {
+        TestModelStub::create(['cn' => 'John']);
+        TestModelStub::create(['cn' => 'Jane']);
+        TestModelStub::create(['cn' => 'Bob']);
+
+        $callbacks = 0;
+
+        $result = TestModelStub::chunk(2, function () use (&$callbacks) {
+            $callbacks++;
+
+            return false;
+        });
+
+        $this->assertFalse($result);
+        $this->assertSame(1, $callbacks);
+    }
+
     public function test_has_many_relationship()
     {
         $group = Group::create(['cn' => 'Accounting']);


### PR DESCRIPTION
## Summary

Make the directory emulator honor the page size passed to model `chunk()` queries.

The emulated builder now loads its in-memory result set and yields it in correctly sized chunks. This also gives `each()`, which is built on `chunk()`, the expected behavior.

## Root cause

The emulator inherited the regular LDAP lazy paginator. That paginator relies on paged-results server controls, which the emulator does not implement.

The fake LDAP response therefore ended pagination after the first request, while the emulated query returned every matching record in that request. The callback received the complete result set instead of the requested page size.

Part of #709